### PR TITLE
Add Python and Jupyter extensions to devcontainer

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,5 +4,9 @@
   ],
   "hostRequirements": {
      "gpus": 1
-  }
+  },
+  "extensions": [
+    "ms-python.python",
+    "ms-toolsai.jupyter"
+  ]
 }


### PR DESCRIPTION
Adds the Python and Jupyter extensions to `.devcontainer.json` in order to install them automatically in new codespaces.

I used the `Add to devcontainer.json` command to make this PR:

![Add to devcontainer.json](https://user-images.githubusercontent.com/19893438/172731868-7cc0bbc9-0683-402f-b479-96b13596ab5c.gif)